### PR TITLE
Improve BigInt and BigDecimal support

### DIFF
--- a/src/valip/predicates.clj
+++ b/src/valip/predicates.clj
@@ -6,6 +6,8 @@ Clojure implementations."
             [cljs.reader :refer [read-string]])
   (:refer-clojure :exclude [read-string]))
 
+(def ^:private number-re #"\s*[+-]?\d+(\.\d*M?|M|N)?\s*")
+
 (defn present?
   "Returns false if x is nil or blank, true otherwise."
   [x]
@@ -49,7 +51,7 @@ Clojure implementations."
 (defn decimal-string?
   "Returns true if the string represents a decimal number."
   [s]
-  (boolean (re-matches #"\s*[+-]?\d+(\.\d*M?|M|N)?\s*" s)))
+  (boolean (re-matches number-re s)))
 
 (defn digits?
   "Returns true if a string consists only of numerical digits."
@@ -62,7 +64,7 @@ Clojure implementations."
   (boolean (re-matches #"[A-Za-z0-9]+" s)))
 
 (defn- parse-number [x]
-  (if (and (string? x) (re-matches #"\s*[+-]?\d+(\.\d*M?|M|N)?\s*" x))
+  (if (and (string? x) (re-matches number-re x))
     (read-string x)))
 
 (defn gt

--- a/src/valip/predicates.clj
+++ b/src/valip/predicates.clj
@@ -49,7 +49,7 @@ Clojure implementations."
 (defn decimal-string?
   "Returns true if the string represents a decimal number."
   [s]
-  (boolean (re-matches #"\s*[+-]?\d+(\.\d+(M|M|N)?)?\s*" s)))
+  (boolean (re-matches #"\s*[+-]?\d+(\.\d*M?|M|N)?\s*" s)))
 
 (defn digits?
   "Returns true if a string consists only of numerical digits."
@@ -62,7 +62,7 @@ Clojure implementations."
   (boolean (re-matches #"[A-Za-z0-9]+" s)))
 
 (defn- parse-number [x]
-  (if (and (string? x) (re-matches #"\s*[+-]?\d+(\.\d+M|M|N)?\s*" x))
+  (if (and (string? x) (re-matches #"\s*[+-]?\d+(\.\d*M?|M|N)?\s*" x))
     (read-string x)))
 
 (defn gt

--- a/test/valip/test/predicates.clj
+++ b/test/valip/test/predicates.clj
@@ -69,6 +69,14 @@
   (is (decimal-string? "  8  "))
   (is (decimal-string? "1.1"))
   (is (decimal-string? "3.14159"))
+  (is (not (decimal-string? "N")))
+  (is (not (decimal-string? "M")))
+  (is (decimal-string? "3N"))
+  (is (decimal-string? "3M"))
+  (is (not (decimal-string? "3.N")))
+  (is (decimal-string? "3.M"))
+  (is (not (decimal-string? "3.14159N")))
+  (is (decimal-string? "3.14159M"))
   (is (not (decimal-string? "foo")))
   (is (not (decimal-string? "10x")))
   (is (not (decimal-string? ""))))
@@ -96,6 +104,32 @@
   (is ((lte 10) "10"))
   (is (not ((lte 10) "11")))
   (is (not ((lte 10) ""))))
+
+(deftest comparing-bigint-bigdec
+  (are [input is-lt is-lte is-gte is-gt]
+    (and (= is-lt  (boolean ((lt  10) input)))
+         (= is-lte (boolean ((lte 10) input)))
+         (= is-gte (boolean ((gte 10) input)))
+         (= is-gt  (boolean ((gt  10) input))))
+    "9"      true  true  false false
+    "9N"     true  true  false false
+    "9M"     true  true  false false
+    "9."     true  true  false false
+    "9.M"    true  true  false false
+    "9.99"   true  true  false false
+    "9.99M"  true  true  false false
+    "10"     false true  true  false
+    "10N"    false true  true  false
+    "10M"    false true  true  false
+    "10."    false true  true  false
+    "10.M"   false true  true  false
+    "10.0"   false true  true  false
+    "10.0M"  false true  true  false
+    "10.01"  false false true  true
+    "10.01M" false false true  true
+    "11"     false false true  true
+    "11N"    false false true  true
+    "11M"    false false true  true))
 
 (deftest test-over
   (is (= over gt)))


### PR DESCRIPTION
Original regular expressions in `valip.predicates` not quite consistent with the Clojure reader (or each other) in handling numbers ending with `N`, `M`, or `.`.
- Added tests to exercise these cases.
- Updated regular expressions.
- Extracted this regexp to a var so `decimal-string?` and `parse-number` will continue to have the same semantics even if this regexp is changed in the future.
